### PR TITLE
Fixes error on putting to already existing subjects

### DIFF
--- a/src/avro_registry/store.clj
+++ b/src/avro_registry/store.clj
@@ -32,9 +32,11 @@
        (map #(subs % 8))))
 
 (defn create-subject [subject]
-  (j/db-do-commands (db) (j/create-table-ddl (->table subject)
-                                             [:id :smallserial "PRIMARY KEY"]
-                                             [:schema "varchar(4096)"])))
+  (j/db-do-commands (db)
+                    (str "CREATE TABLE IF NOT EXISTS "
+                         (name (->table subject))
+                         " (id smallserial PRIMARY KEY, schema varchar(4096))")))
+
 (defn get-all-schemas [subject]
   (j/query (db) [(str "SELECT * from " (name (->table subject)))])
   )


### PR DESCRIPTION
If I do a PUT /subject twice, I get an exception since the table already exists. This way the PUT call will be idempotent. An existing subject would not be altered and no exception will be thrown.
